### PR TITLE
[add] improve performance of resize event listening

### DIFF
--- a/modules/elements/elements/hd-lottie/js/hd-lottie.js
+++ b/modules/elements/elements/hd-lottie/js/hd-lottie.js
@@ -142,7 +142,8 @@ UIkit.util.$$('.hd-lottie').forEach(el => {
 	let x = new hdLottie(el);
 	x.init();
 
-	window.addEventListener('resize', () => {
-		if (x.renderer === 'canvas') lottie.resize(x.name);
-	})
+	if (x.renderer === 'canvas')
+		window.addEventListener('resize', () => {
+			lottie.resize(x.name);
+		})
 });


### PR DESCRIPTION
This PR removes adding a listener in case of the renderer is not canvas.
Related to #25 