### PR TITLE
add height expand option to Flipcard element

### DIFF
--- a/modules/elements/elements/hd-flipcard/element.json
+++ b/modules/elements/elements/hd-flipcard/element.json
@@ -240,6 +240,12 @@
             "show": "panel_style",
             "enable": "image && image_align != 'between'"
         },
+        "height_expand": {
+            "label": "Height",
+            "description": "Expand the height of the element to fill the available space in the column.",
+            "type": "checkbox",
+            "text": "Fill the available column space"
+        },
         "html_element": "${builder.html_element}",
         "title_style": {
             "label": "Style",
@@ -1583,6 +1589,7 @@
                                 "panel_style",
                                 "panel_padding",
                                 "panel_image_no_padding",
+                                "height_expand",
                                 "html_element"
                             ]
                         },

--- a/modules/elements/elements/hd-flipcard/templates/template.php
+++ b/modules/elements/elements/hd-flipcard/templates/template.php
@@ -250,6 +250,9 @@ $el = $this->el($props['html_element'] ?: 'div', [
         'hd-flipcard',
         'hd-flipcard-{flip_animation}',
         'hd-flipcard-3d {@3d_effect}',
+
+        // Expand to column height
+        'uk-flex-1 {@height_expand}',
     ],
 
     'data-flipmode' => [


### PR DESCRIPTION
Add option to expand the height of the Flipcard to the height of the column it is in. It's important that the option name is `height_expand`. Do not change it. Otherwise the column doesn't know that it contains an element which wants to expand its height.