### PR TITLE
add text color option for transparent header to Flipcard, Image Comparison and Timeline elements

### DIFF
--- a/modules/elements/elements/hd-flipcard/element.json
+++ b/modules/elements/elements/hd-flipcard/element.json
@@ -768,6 +768,18 @@
             },
             "enable": "image && image_svg_inline"
         },
+        "image_text_color": {
+            "label": "Text Color",
+            "description": "Set light or dark color mode for text, buttons and controls if a sticky transparent navbar is displayed above.",
+            "type": "select",
+            "options": {
+                "None": "",
+                "Light": "light",
+                "Dark": "dark"
+            },
+            "source": true,
+            "enable": "image"
+        },
         "link_style": {
             "label": "Style",
             "description": "Set the link style.",
@@ -1432,6 +1444,18 @@
             "text": "Load image eagerly",
             "enable": "image_back"
         },
+        "image_back_text_color": {
+            "label": "Text Color",
+            "description": "Set light or dark color mode for text, buttons and controls if a sticky transparent navbar is displayed above.",
+            "type": "select",
+            "options": {
+                "None": "",
+                "Light": "light",
+                "Dark": "dark"
+            },
+            "source": true,
+            "enable": "image_back"
+        },
         "link_back_style": {
             "label": "Style",
             "description": "Set the link style.",
@@ -1652,7 +1676,8 @@
                                 "image_margin",
                                 "image_svg_inline",
                                 "image_svg_animate",
-                                "image_svg_color"
+                                "image_svg_color",
+                                "image_text_color"
                             ]
                         },
                         {
@@ -1743,7 +1768,8 @@
                                 "image_back_svg_inline",
                                 "image_back_svg_animate",
                                 "image_back_svg_color",
-                                "image_back_loading"
+                                "image_back_loading",
+                                "image_back_text_color"
                             ]
                         },
                         {

--- a/modules/elements/elements/hd-flipcard/templates/template-image.php
+++ b/modules/elements/elements/hd-flipcard/templates/template-image.php
@@ -14,6 +14,7 @@ if ($props['image']) {
 
             'uk-text-{image_svg_color} {@image_svg_inline}' => $this->isImage($props['image']) == 'svg',
             'uk-margin[-{image_margin}]-top {@!image_margin: remove} {@!image_box_decoration}' => $props['image_align'] == 'between' || ($props['image_align'] == 'bottom' && !($props['panel_style'] && $props['panel_image_no_padding'])),
+            'uk-inverse-{image_text_color}',
         ],
 
         'src' => $props['image'],

--- a/modules/elements/elements/hd-flipcard/templates/template-image_back.php
+++ b/modules/elements/elements/hd-flipcard/templates/template-image_back.php
@@ -16,6 +16,7 @@ if ($props['image_back']) {
 
             'uk-text-{image_back_svg_color} {@image_back_svg_inline}' => $this->isImage($props['image_back']) == 'svg',
             'uk-margin[-{image_back_margin}]-top {@!image_back_margin: remove} {@!image_back_box_decoration} {@!image_back_transition}' => $props['image_back_align'] == 'between' || ($props['image_back_align'] == 'bottom' && !($props['panel_back_style'] && $props['panel_back_image_no_padding'])),
+            'uk-inverse-{image_back_text_color}',
         ],
 
         'src' => $props['image_back'],

--- a/modules/elements/elements/hd-image-comparison/element.json
+++ b/modules/elements/elements/hd-image-comparison/element.json
@@ -175,6 +175,17 @@
             "text": "Inverse style",
             "enable": "$match(image_box_decoration, '^(default|primary|secondary)$')"
         },
+        "text_color": {
+            "label": "Text Color",
+            "description": "Set light or dark color mode for text, buttons and controls if a sticky transparent navbar is displayed above.",
+            "type": "select",
+            "options": {
+                "None": "",
+                "Light": "light",
+                "Dark": "dark"
+            },
+            "source": true
+        },
         "icon_color": {
             "label": "Slider Icon Color",
             "description": "Select the icon color.",
@@ -302,7 +313,8 @@
                                 "image_border",
                                 "image_box_shadow",
                                 "image_box_decoration",
-                                "image_box_decoration_inverse"
+                                "image_box_decoration_inverse",
+                                "text_color"
                             ]
                         },
                         {

--- a/modules/elements/elements/hd-image-comparison/templates/template.php
+++ b/modules/elements/elements/hd-image-comparison/templates/template.php
@@ -4,7 +4,13 @@
 
 $uniqid = uniqid('hd-');
 
-$el = $this->el('div');
+$el = $this->el('div', [
+
+    'class' => [
+        'uk-inverse-{text_color}',
+    ],
+
+]);
 
 // Image Before
 $image_before = $this->el('image', [

--- a/modules/elements/elements/hd-timeline/element.json
+++ b/modules/elements/elements/hd-timeline/element.json
@@ -856,6 +856,18 @@
             },
             "enable": "show_image && image_svg_inline"
         },
+        "image_text_color": {
+            "label": "Text Color",
+            "description": "Set light or dark color mode for text, buttons and controls if a sticky transparent navbar is displayed above.",
+            "type": "select",
+            "options": {
+                "None": "",
+                "Light": "light",
+                "Dark": "dark"
+            },
+            "source": true,
+            "enable": "show_image"
+        },
         "link_target": {
             "label": "Target",
             "type": "checkbox",
@@ -1091,7 +1103,8 @@
                                 "image_margin",
                                 "image_svg_inline",
                                 "image_svg_animate",
-                                "image_svg_color"
+                                "image_svg_color",
+                                "image_text_color"
                             ]
                         },
                         {

--- a/modules/elements/elements/hd-timeline_item/element.json
+++ b/modules/elements/elements/hd-timeline_item/element.json
@@ -98,6 +98,18 @@
             "source": true,
             "enable": "image"
         },
+        "image_text_color": {
+            "label": "Text Color",
+            "description": "Set light or dark color mode for text, buttons and controls if a sticky transparent navbar is displayed above.",
+            "type": "select",
+            "options": {
+                "None": "",
+                "Light": "light",
+                "Dark": "dark"
+            },
+            "source": true,
+            "enable": "image"
+        },
         "status": "${builder.statusItem}",
         "source": "${builder.source}"
     },
@@ -132,7 +144,7 @@
                         {
                             "label": "Image",
                             "type": "group",
-                            "fields": ["image_focal_point"]
+                            "fields": ["image_focal_point", "image_text_color"]
                         }
                     ]
                 },

--- a/modules/elements/elements/hd-timeline_item/templates/template-image.php
+++ b/modules/elements/elements/hd-timeline_item/templates/template-image.php
@@ -12,6 +12,8 @@ if ($props['image']) {
             'uk-transition-{image_transition} uk-transition-opaque' => $props['link'] && ($element['image_link'] || $element['panel_link']),
 
             'uk-text-{image_svg_color} {@image_svg_inline}' => $this->isImage($props['image']) == 'svg',
+
+            'uk-inverse-{0}' => $element['image_text_color'],
         ],
 
         'src' => $props['image'],

--- a/modules/elements/elements/hd-timeline_item/templates/template.php
+++ b/modules/elements/elements/hd-timeline_item/templates/template.php
@@ -7,6 +7,7 @@ if ($props['icon'] && !$props['image']) { $element['panel_image_no_padding'] = '
 
 // Override default settings
 $element['panel_style'] = $props['panel_style'] ?: $element['panel_style'];
+$element['image_text_color'] = $props['image_text_color'] ?: $element['image_text_color'];
 
 // Image
 $props['image'] = $this->render("{$__dir}/template-image", compact('props'));


### PR DESCRIPTION
Add an text color option for images even when the element itself don't need it. It will recolor a fully transparent navbar so it is better readable above the image. I didn't add it to the Slideshow Grid element because it already has a text color option. So I think it should already work but I haven't tested it. Please do if it works and my changes also 😃