### PR TITLE
feat(counter): add support for unit position and spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 ### Added
 
-- option to place unit before number on counter element
-- option to add space between number and unit on counter element
+- option to place start unit before number on counter element
+- option to add space between number and start unit on counter element
+- option for a second unit (end unit) after the number on counter element
+- options for space and size for the end unit on counter element
 
 ### Changed
 
 - refactored template logic for conciseness in counter element
+- renamed original unit settings/variables to use 'start_unit' for clarity in counter element
+- renamed unit size settings to unit style settings (e.g., 'Start Unit Size' to 'Start Unit Style') in counter element
 
 ## 1.9.0
 
@@ -53,8 +57,7 @@
 
 ### Fixed
 
-- error if percentage is empty in counter element
-- render conditions in toggle element
+- automatically recompile style
 
 ## 1.7.0
 

--- a/modules/elements/elements/hd-counter/element.json
+++ b/modules/elements/elements/hd-counter/element.json
@@ -10,9 +10,12 @@
     "defaults": {
         "text": "",
         "number": 1000,
-        "unit": "",
-        "unit_position_before": false,
-        "unit_space": true,
+        "unit_start": "",
+        "unit_start_space": true,
+        "unit_end": "",
+        "unit_end_space": true,
+        "unit_start_style": "number-size",
+        "unit_end_style": "number-size",
         "text_style": "",
         "text_color": "",
         "number_size": "",
@@ -45,24 +48,81 @@
             "type": "number",
             "source": true
         },
-        "unit": {
-            "label": "Unit",
-            "description": "Enter the text that will be displayed before or after the counter.",
+        "unit_start": {
+            "label": "Start Unit",
+            "description": "Enter the text that will be displayed before the counter.",
             "type": "text",
             "source": true
         },
-        "unit_position_before": {
-            "label": "Unit Position",
-            "type": "checkbox",
-            "text": "Display the unit before the number",
-            "enable": "unit"
-        },
-        "unit_space": {
-            "label": "Space Before/After Unit",
-            "description": "Add a space between the number and the unit.",
+        "unit_start_space": {
+            "label": "Space After Start Unit",
+            "description": "Add a space between the start unit and the number.",
             "type": "checkbox",
             "text": "Add space",
-            "enable": "unit"
+            "enable": "unit_start"
+        },
+        "unit_end": {
+            "label": "End Unit",
+            "description": "Enter the text that will be displayed after the counter.",
+            "type": "text",
+            "source": true
+        },
+        "unit_end_space": {
+            "label": "Space Before End Unit",
+            "description": "Add a space between the number and the end unit.",
+            "type": "checkbox",
+            "text": "Add space",
+            "enable": "unit_end"
+        },
+        "unit_start_style": {
+            "label": "Start Unit Style",
+            "description": "Select a predefined style for the start unit.",
+            "type": "select",
+            "options": {
+                "Same as number size": "number-size",
+                "None": "",
+                "Text Meta": "text-meta",
+                "Text Lead": "text-lead",
+                "Text Small": "text-small",
+                "Text Large": "text-large",
+                "Heading 2X-Large": "heading-2xlarge",
+                "Heading X-Large": "heading-xlarge",
+                "Heading Large": "heading-large",
+                "Heading Medium": "heading-medium",
+                "Heading Small": "heading-small",
+                "Heading H1": "h1",
+                "Heading H2": "h2",
+                "Heading H3": "h3",
+                "Heading H4": "h4",
+                "Heading H5": "h5",
+                "Heading H6": "h6"
+            },
+            "enable": "unit_start"
+        },
+            "unit_end_style": {
+                "label": "End Unit Style",
+                "description": "Select a predefined style for the end unit.",
+                "type": "select",
+                "options": {
+                    "Same as number size": "number-size",
+                    "None": "",
+                    "Text Meta": "text-meta",
+                    "Text Lead": "text-lead",
+                    "Text Small": "text-small",
+                    "Text Large": "text-large",
+                    "Heading 2X-Large": "heading-2xlarge",
+                    "Heading X-Large": "heading-xlarge",
+                    "Heading Large": "heading-large",
+                    "Heading Medium": "heading-medium",
+                    "Heading Small": "heading-small",
+                    "Heading H1": "h1",
+                    "Heading H2": "h2",
+                    "Heading H3": "h3",
+                    "Heading H4": "h4",
+                    "Heading H5": "h5",
+                    "Heading H6": "h6"
+                },
+                "enable": "unit_end"    
         },
         "text_style": {
             "label": "Text Style",
@@ -143,31 +203,6 @@
                 "Danger": "danger"
             },
             "enable": "number"
-        },
-        "unit_size": {
-            "label": "Unit Size",
-            "description": "Select a predefined unit style, including color, size and font-family.",
-            "type": "select",
-            "options": {
-                "Same as number size": "number-size",
-                "None": "",
-                "Text Meta": "text-meta",
-                "Text Lead": "text-lead",
-                "Text Small": "text-small",
-                "Text Large": "text-large",
-                "Heading 2X-Large": "heading-2xlarge",
-                "Heading X-Large": "heading-xlarge",
-                "Heading Large": "heading-large",
-                "Heading Medium": "heading-medium",
-                "Heading Small": "heading-small",
-                "Heading H1": "h1",
-                "Heading H2": "h2",
-                "Heading H3": "h3",
-                "Heading H4": "h4",
-                "Heading H5": "h5",
-                "Heading H6": "h6"
-            },
-            "enable": "unit"
         },
         "separator_locale": {
             "label": "Separator locale",
@@ -263,9 +298,10 @@
                     "fields": [
                         "text",
                         "number",
-                        "unit",
-                        "unit_position_before",
-                        "unit_space"
+                        "unit_start",
+                        "unit_start_space",
+                        "unit_end",
+                        "unit_end_space"
                     ]
                 },
                 {
@@ -275,7 +311,8 @@
                         "text_color",
                         "number_size",
                         "number_color",
-                        "unit_size",
+                        "unit_start_style",
+                        "unit_end_style",
                         "separator_locale",
                         "show_circle",
                         "percentage",

--- a/modules/elements/elements/hd-counter/templates/template.php
+++ b/modules/elements/elements/hd-counter/templates/template.php
@@ -81,39 +81,63 @@ $numberEl = $this->el('span', [
 
 ]);
 
-$unitEl = $this->el('span', [
+// Define Start Unit Element (Renamed from unitEl)
+$startUnitEl = $this->el('span', [
 
     'class' => [
-        'el-unit',
-        'uk-{number_size} {@unit_size: number-size}',
-        'uk-{unit_size} {@!unit_size: number-size}',
+        'el-unit el-unit-start',
+        'uk-{number_size} {@unit_start_style: number-size}',
+        'uk-{unit_start_style} {@!unit_start_style: number-size}',
         'uk-text-{number_color}',
     ],
 
 ]);
 
-// Prepare number and unit parts - Refactored
-$number_html = $props['number'] ? $numberEl($props, $props['number']) : '';
-$unit_html = $props['unit'] ? $unitEl($props, $props['unit']) : '';
-$number_unit_output = '';
-$use_space = !empty($props['unit_space']); // Check the new option
+$endUnitEl = $this->el('span', [
+    'class' => [
+        'el-unit el-unit-end',
+        'uk-{number_size} {@unit_end_style: number-size}',
+        'uk-{unit_end_style} {@!unit_end_style: number-size}',
+        'uk-text-{number_color}',
+    ],
+]);
 
-if ($props['unit_position_before'] && $unit_html) {
-    // Unit first
-    $number_unit_output = $unit_html;
-    if ($number_html) {
-        $number_unit_output .= ($use_space ? ' ' : '') . $number_html;
-    }
-} elseif ($number_html) {
-    // Number first
-    $number_unit_output = $number_html;
-    if ($unit_html) {
-        $number_unit_output .= ($use_space ? ' ' : '') . $unit_html;
-    }
-} elseif ($unit_html) {
-    // Only unit
-    $number_unit_output = $unit_html;
+// Prepare number and unit parts - Refactored for Start and End Units
+$number_html = $props['number'] ? $numberEl($props, $props['number']) : '';
+$start_unit_html = $props['unit_start'] ? $startUnitEl($props, $props['unit_start']) : '';
+$end_unit_html = $props['unit_end'] ? $endUnitEl($props, $props['unit_end']) : '';
+
+$use_start_space = !empty($props['unit_start_space']);
+$use_end_space = !empty($props['unit_end_space']);
+
+$output_parts = [];
+
+// Build output: Start Unit -> Number -> End Unit
+
+// Add Start Unit
+if ($start_unit_html) {
+    $output_parts[] = $start_unit_html;
 }
+
+// Add Number
+if ($number_html) {
+    // Add space before number only if start unit exists AND space is enabled
+    if (!empty($output_parts) && $use_start_space) {
+        $output_parts[] = ' ';
+    }
+    $output_parts[] = $number_html;
+}
+
+// Add End Unit
+if ($end_unit_html) {
+    // Add space before end unit only if preceding content exists (start unit or number) AND space is enabled
+    if (!empty($output_parts) && $use_end_space) {
+        $output_parts[] = ' ';
+    }
+    $output_parts[] = $end_unit_html;
+}
+
+$number_unit_output = implode('', $output_parts);
 
 // Prepare text part
 $text_output = $props['text'] ? $textEl($props) . '<br>' . $props['text'] . '</span>' : '';
@@ -147,7 +171,7 @@ $text_output = $props['text'] ? $textEl($props) . '<br>' . $props['text'] . '</s
             </svg>
 
             <div class="uk-position-center uk-overlay">
-                <?php // Conditionally render unit and number based on unit_position_before
+                <?php // Start Unit -> Number -> End Unit
                 echo $number_unit_output;
                 ?>
                 <?php if ($text_output) : ?><?= $text_output ?><?php endif ?>
@@ -158,7 +182,7 @@ $text_output = $props['text'] ? $textEl($props) . '<br>' . $props['text'] . '</s
     <?php else : ?>
 
         <div>
-            <?php // Conditionally render unit and number based on unit_position_before
+            <?php // Start Unit -> Number -> End Unit
             echo $number_unit_output;
             ?>
             <?php if ($text_output) : ?><?= $text_output ?><?php endif ?>


### PR DESCRIPTION
## Description
This PR adds a setting to place the unit in front of the number in the counter element, and another to remove the space between.

## Motivation
I have used the HD counter element on a few sites, and would like the ability to place the unit in front of the number, for currencies etc.

## Implementation
- Added toggle button for unit position
- Added toggle button to show/hide space between unit and number
- Refactored template logic for conciseness in counter element

## Screenshots
![image](https://github.com/user-attachments/assets/d4c14f48-d88c-4cf4-aa2c-1dfda6ab0d0d)
![image](https://github.com/user-attachments/assets/e99ed6c7-a273-4aa7-8545-79e6167c7444)
![image](https://github.com/user-attachments/assets/aeb41bf3-8e5e-4577-9263-4db402f4b1ca)
![image](https://github.com/user-attachments/assets/2692a7ca-88b5-43b8-8c1f-9e88810af8eb)
